### PR TITLE
Update Cursively benchmark code.

### DIFF
--- a/benchmark.cmd
+++ b/benchmark.cmd
@@ -1,2 +1,2 @@
 dotnet build -c Release source/CsvBenchmark.sln
-bin\release\net5.0\CsvBenchmark.exe
+bin\release\net5.0\CsvBenchmark.exe --iterationTime 1000

--- a/source/CsvBenchmark/CsvReaderBenchmarks.cs
+++ b/source/CsvBenchmark/CsvReaderBenchmarks.cs
@@ -221,7 +221,7 @@ namespace CsvBenchmark
 					chunk = new ReadOnlySpan<byte>(bytes, 0, bytesUsed + chunk.Length);
 					bytesUsed = 0;
 				}
-				var str = chunk.Length == 1 && chunk[0] < 128 && doPooling
+				var str = doPooling && chunk.Length == 1 && chunk[0] < 128
 					? pool[chunk[0]]
 					: Encoding.UTF8.GetString(chunk);
 				ordinal++;

--- a/source/CsvBenchmark/TestData.cs
+++ b/source/CsvBenchmark/TestData.cs
@@ -112,6 +112,11 @@ Combined_Key,
 			return new MemoryStream(CachedUtfData);
 		}
 
+		public static ReadOnlyMemory<byte> GetUtf8Array()
+		{
+			return CachedUtfData;
+		}
+
 		public static DbDataReader GetData()
 		{
 


### PR DESCRIPTION
- VisitPartialFieldContents is required for correctness
- Use the original byte array, since we have one, instead of forcing a stream around it
- Set iteration time to 1 second, to work around dotnet/BenchmarkDotNet#837 while we wait for a version of this package that includes dotnet/BenchmarkDotNet#1573