### PR TITLE
Add ExcelMapper and NPOI.Mapper to XlsxDataBinderBenchmark

### DIFF
--- a/source/Benchmarks/Benchmarks.csproj
+++ b/source/Benchmarks/Benchmarks.csproj
@@ -24,6 +24,8 @@
 		<PackageReference Include="DocumentFormat.OpenXml" Version="3.3.0" />
 
 		<PackageReference Include="Excel-PRIME" Version="3.2601.11" />
+
+		<PackageReference Include="ExcelMapper" Version="6.0.615" />
 		<PackageReference Include="FastCsvParser" Version="1.1.1" />
 		<PackageReference Include="FlameCsv" Version="0.3.1" />
 		<PackageReference Include="FlatFiles" Version="5.0.4" />
@@ -38,6 +40,7 @@
 		<PackageReference Include="MiniExcel" Version="1.42.0" />
 		<PackageReference Include="NanoXLSX" Version="2.6.7" />
 		<PackageReference Include="NLight" Version="2.1.1" />
+		<PackageReference Include="Npoi.Mapper" Version="6.2.2" />
 		<PackageReference Include="NReco.Csv" Version="1.0.3" />
 		<PackageReference Include="FSharp.Data" Version="6.6.0" />
 		<PackageReference Include="Microsoft.VisualBasic" Version="10.3.0" />

--- a/source/Benchmarks/XlsxDataBinderBenchmarks.cs
+++ b/source/Benchmarks/XlsxDataBinderBenchmarks.cs
@@ -1,6 +1,8 @@
 ﻿using BenchmarkDotNet.Attributes;
 using MiniExcelLibs;
 using System.IO;
+using Ganss.Excel;
+using Npoi.Mapper;
 
 namespace Benchmarks;
 
@@ -24,6 +26,25 @@ public class ExcelBinderBenchmarks
 	{
 		using var s = File.OpenRead(file);
 		foreach(var rec in s.Query<SalesRecord>())
+		{
+		}
+	}
+
+	[Benchmark(Description =  "ExcelMapperXlsx (based on NPOI)")]
+	public void ExcelMapperXlsx()
+	{
+		var excel = new ExcelMapper(file);
+		var salesRecords = excel.Fetch<SalesRecord>();
+		foreach(var rec in salesRecords)
+		{
+		}
+	}
+	[Benchmark(Description =  "NPOI.MapperXlsx (based on NPOI)")]
+	public void NPOIMapperXlsx()
+	{
+		var mapper = new Mapper(file);
+		var salesRecords = mapper.Take<SalesRecord>();
+		foreach(var rec in salesRecords)
 		{
 		}
 	}


### PR DESCRIPTION
## Summary 

BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.8039/25H2/2025Update/HudsonValley2)
12th Gen Intel Core i5-12400 2.50GHz, 1 CPU, 12 logical and 6 physical cores
.NET SDK 10.0.201
  [Host] : .NET 10.0.5 (10.0.5, 10.0.526.15411), X64 RyuJIT x86-64-v3

Job=InProcess  Toolchain=InProcessEmitToolchain  MaxIterationCount=6  
MinIterationCount=1  WarmupCount=2  

| Method                            | Mean       | Error     | Allocated  |
|---------------------------------- |-----------:|----------:|-----------:|
| SylvanXlsx                        |   221.3 ms |  11.88 ms |   10.65 MB |
| MiniExcelXlsx                     |   580.7 ms |  19.64 ms |  619.37 MB |
| 'NPOI.Mapper (based on NPOI)'     | 2,815.7 ms | 369.88 ms | 1070.34 MB |
| 'ExcelMapperXlsx (based on NPOI)' | 2,978.2 ms | 442.51 ms |  1443.8 MB |
