### PR TITLE
Upgrade NPOI to 2.8.0-preview1

### DIFF
--- a/source/Benchmarks/Benchmarks.csproj
+++ b/source/Benchmarks/Benchmarks.csproj
@@ -53,7 +53,7 @@
 		<PackageReference Include="EPPlus" Version="7.7.0" />
 		<PackageReference Include="ExcelDataReader" Version="3.8.0" />
 		<PackageReference Include="FastExcel" Version="3.0.13" />
-		<PackageReference Include="NPOI" Version="2.7.6" />
+		<PackageReference Include="NPOI" Version="2.8.0-preview1" />
 		<PackageReference Include="Sep" Version="0.12.3" />
 		<PackageReference Include="SpreadsheetLight" Version="3.5.0" />
 		<PackageReference Include="SpreadSheetTasks" Version="0.5.0" />


### PR DESCRIPTION
## Summary 
                                                                                                           
BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.8039/25H2/2025Update/HudsonValley2)
11th Gen Intel Core i7-1165G7 2.80GHz (Max: 1.69GHz), 1 CPU, 8 logical and 4 physical cores                
.NET SDK 10.0.103                                                                                          
  [Host] : .NET 10.0.3 (10.0.3, 10.0.326.7603), X64 RyuJIT x86-64-v4                                       
                                                                                                           
Job=InProcess  Toolchain=InProcessEmitToolchain  MaxIterationCount=6  
MinIterationCount=1  WarmupCount=2  StdDev=1.680 s  
Gen0=179000.0000  Gen1=77000.0000  Gen2=8000.0000  

## Xlsx Reader 
### Before Change (NPOI 2.7.6)

| Method   | Mean    | Error   | Allocated |
|--------- |--------:|--------:|----------:|
| NpoiXlsx | 12.84 s | 6.775 s |   1.23 GB |  

### After Change (NPOI 2.8.0-preview1)

| Method   | Mean    | Error   | Allocated |
|--------- |--------:|--------:|----------:|
| NpoiXlsx | 7.431 s | 1.319 s | 973.48 MB |   
